### PR TITLE
Printing with proper symbol table references

### DIFF
--- a/compiler/SymbolTable.java
+++ b/compiler/SymbolTable.java
@@ -25,15 +25,9 @@ public class SymbolTable {
         return symbolTable.containsKey(symbol);
     }
 
-    public void updateSymbolValue(String symbol, String value) {
-        Variable var = symbolTable.get(symbol);
-        var.setValue(value);
-        symbolTable.replace(symbol, var);
-    }
-
     public void printAll() {
         for( String key : symbolTable.keySet()) {
-            System.out.println("\nSymbol: " + key + ",\tValue: " + symbolTable.get(key).getValue().toString() + ",\tType: " + symbolTable.get(key).getVarType());
+            System.out.println("\nSymbol: " + key + ",\tVar Index: " + symbolTable.get(key).getVarIndex() +  ",\tType: " + symbolTable.get(key).getVarType());
         }
     }
 

--- a/compiler/Variable.java
+++ b/compiler/Variable.java
@@ -7,50 +7,23 @@ public class Variable {
     protected static final int TYPE_STRING = 2;
 
     private int varType;
-    private Object value;
+    private final int varIndex;
 
-
-
-    private final int stackIndex;
-
-    public Variable(int VAR_TYPE, int stackIndex) {
+    public Variable(int VAR_TYPE, int varIndex) {
         this.varType = VAR_TYPE;
-        this.stackIndex = stackIndex;
+        this.varIndex = varIndex;
     }
 
-    public Variable(String val, int VAR_TYPE, int stackIndex) {
-        this.value = new Object();
+    public Variable(String val, int VAR_TYPE, int varIndex) {
         this.varType = VAR_TYPE;
-        this.stackIndex = stackIndex;
-        switch(VAR_TYPE) {
-            case TYPE_INTEGER:
-                this.value = Integer.valueOf(val);
-                break;
-            case TYPE_STRING:
-                this.value = val;
-                break;
-        }
-    }
-
-    public void setValue(String val) {
-        switch(varType) {
-            case TYPE_INTEGER:
-                this.value = Integer.valueOf(val);
-                break;
-            case TYPE_STRING:
-                this.value = val;
-                break;
-        }
+        this.varIndex = varIndex;
     }
 
     public int getVarType() {
         return varType;
     }
 
-    public Object getValue() {
-        return value;
-    }
-    public int getStackIndex() {
-        return stackIndex;
+    public int getVarIndex() {
+        return varIndex;
     }
 }

--- a/tests/program1.kc
+++ b/tests/program1.kc
@@ -16,6 +16,7 @@ SET name := "zac"
 PRINT x
 PRINT y
 PRINT name
+PRINT "COWAN"
 
 END
 


### PR DESCRIPTION
Previous printing stored actual value of variables in the symbol table (this was an incorrect implementation). Now the Variable class, which is the value of our hash map keys only stores the variable type and varIndex. 

A Variables varIndex is set in the DECLARE section and is later stored to the actual location in the set var section.

To load a variable reference you now simply get the Variable of the given symbol and load its varIndex.