### PR TITLE
Arithmetic refactor

### DIFF
--- a/tests/program1.kc
+++ b/tests/program1.kc
@@ -3,17 +3,21 @@ PROGRAM Program1
 DECLARE
 	INTEGER x
 	INTEGER y
-    INTEGER z
+    STRING first
+    STRING last
+    STRING name
 
 BEGIN
 
 SET x := 12
-SET y := 13
-SET z := x + y
+SET y := 10
+SET first := "Zac"
+SET last := "Cowan"
+SET name := bob
 
 PRINT x
 PRINT y
-PRINT z
+#PRINT z
 
 END
 


### PR DESCRIPTION
Arithmetic operations are now properly evaluated. 

Originally everything occurred at the set-var level, which was not flexible. 

Now bytecode calls are atomic and occur at the leaves of the tree.

For example, when an "+" operator is visited, the IADD bytecode is called.